### PR TITLE
Use minitest-rails conventions

### DIFF
--- a/lib/generators/thincloud/test/templates/Guardfile
+++ b/lib/generators/thincloud/test/templates/Guardfile
@@ -4,9 +4,9 @@
 guard "minitest" do
   # with Minitest::Spec
   watch(%r|^test/(.*)_test\.rb|)
-  watch(%r|^lib/(.*)([^/]+)\.rb|)  { |m| "test/#{m[1]}#{m[2]}_test.rb" }
-  watch(%r|^test/test_helper\.rb|) { "test" }
-  watch(%r|^test/support/|)        { "test" }
+  watch(%r|^lib/(.*)([^/]+)\.rb|)      { |m| "test/#{m[1]}#{m[2]}_test.rb" }
+  watch(%r|^test/minitest_helper\.rb|) { "test" }
+  watch(%r|^test/support/|)            { "test" }
 
   # Rails 3.2
   watch(%r|^app/controllers/(.*)\.rb|) { |m| "test/controllers/#{m[1]}_test.rb" }

--- a/lib/generators/thincloud/test/templates/Guardfile
+++ b/lib/generators/thincloud/test/templates/Guardfile
@@ -3,15 +3,15 @@
 
 guard "minitest" do
   # with Minitest::Spec
-  watch(%r|^spec/(.*)_spec\.rb|)
-  watch(%r|^lib/(.*)([^/]+)\.rb|)  { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
-  watch(%r|^spec/spec_helper\.rb|) { "spec" }
-  watch(%r|^spec/support/|)        { "spec" }
+  watch(%r|^test/(.*)_test\.rb|)
+  watch(%r|^lib/(.*)([^/]+)\.rb|)  { |m| "test/#{m[1]}#{m[2]}_test.rb" }
+  watch(%r|^test/test_helper\.rb|) { "test" }
+  watch(%r|^test/support/|)        { "test" }
 
   # Rails 3.2
-  watch(%r|^app/controllers/(.*)\.rb|) { |m| "spec/controllers/#{m[1]}_spec.rb" }
-  watch(%r|^app/mailers/(.*)\.rb|)     { |m| "spec/mailers/#{m[1]}_spec.rb" }
-  watch(%r|^app/helpers/(.*)\.rb|)     { |m| "spec/helpers/#{m[1]}_spec.rb" }
-  watch(%r|^app/models/(.*)\.rb|)      { |m| "spec/models/#{m[1]}_spec.rb" }
+  watch(%r|^app/controllers/(.*)\.rb|) { |m| "test/controllers/#{m[1]}_test.rb" }
+  watch(%r|^app/mailers/(.*)\.rb|)     { |m| "test/mailers/#{m[1]}_test.rb" }
+  watch(%r|^app/helpers/(.*)\.rb|)     { |m| "test/helpers/#{m[1]}_test.rb" }
+  watch(%r|^app/models/(.*)\.rb|)      { |m| "test/models/#{m[1]}_test.rb" }
 end
 

--- a/lib/generators/thincloud/test/templates/minitest_helper.rb
+++ b/lib/generators/thincloud/test/templates/minitest_helper.rb
@@ -1,5 +1,5 @@
 require "simplecov"
-SimpleCov.add_filter "spec"
+SimpleCov.add_filter "test"
 SimpleCov.add_filter "config"
 SimpleCov.command_name "MiniTest"
 SimpleCov.start
@@ -18,7 +18,7 @@ require "mocha"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.join("./spec/support/**/*.rb")].sort.each { |f| require f }
+Dir[File.join("./test/support/**/*.rb")].sort.each { |f| require f }
 
 class MiniTest::Rails::ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.

--- a/lib/generators/thincloud/test/templates/test.rake
+++ b/lib/generators/thincloud/test/templates/test.rake
@@ -1,6 +1,6 @@
 require "rake/testtask"
 
-task default: :spec
+task default: :test
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "lib"

--- a/lib/generators/thincloud/test/templates/test.rake
+++ b/lib/generators/thincloud/test/templates/test.rake
@@ -2,9 +2,9 @@ require "rake/testtask"
 
 task default: :spec
 
-Rake::TestTask.new(:spec) do |t|
+Rake::TestTask.new(:test) do |t|
   t.libs << "lib"
-  t.libs << "spec"
-  t.pattern = "spec/**/*_spec.rb"
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
   t.verbose = false
 end

--- a/lib/generators/thincloud/test/test_generator.rb
+++ b/lib/generators/thincloud/test/test_generator.rb
@@ -23,17 +23,17 @@ module Thincloud
           "config.generators { |g| g.test_framework :mini_test, spec: true, fixture: false }"
         end
 
-        empty_directory "spec/models"
-        empty_directory "spec/controllers"
-        empty_directory "spec/mailers"
-        empty_directory "spec/helpers"
-        empty_directory "spec/support"
+        empty_directory "test/models"
+        empty_directory "test/controllers"
+        empty_directory "test/mailers"
+        empty_directory "test/helpers"
+        empty_directory "test/support"
 
-        run "touch spec/{models,controllers,mailers,helpers,support}/.gitkeep"
+        run "touch test/{models,controllers,mailers,helpers,support}/.gitkeep"
 
-        copy_file "spec_helper.rb", "spec/spec_helper.rb"
+        copy_file "minitest_helper.rb", "test/minitest_helper.rb"
 
-        copy_file "spec.rake", "lib/tasks/spec.rake"
+        copy_file "test.rake", "lib/tasks/test.rake"
 
         copy_file "Guardfile"
 


### PR DESCRIPTION
This pull request modifies the generators and templates to use the minitest-rails conventions of a `test` directory and `minitest_helper.rb`.

[Fixes #6]
