### PR TITLE
include factory_girl syntax sugar in minitest spec

### DIFF
--- a/lib/generators/thincloud/test/templates/factory_girl.rb
+++ b/lib/generators/thincloud/test/templates/factory_girl.rb
@@ -1,0 +1,3 @@
+class MiniTest::Spec
+  include FactoryGirl::Syntax::Methods
+end

--- a/lib/generators/thincloud/test/test_generator.rb
+++ b/lib/generators/thincloud/test/test_generator.rb
@@ -15,6 +15,7 @@ module Thincloud
         remove_file "test/minitest_helper.rb"
         copy_file "minitest_helper.rb", "test/minitest_helper.rb"
 
+        copy_file "factory_girl.rb", "test/support/factory_girl.rb"
         copy_file "database_cleaner.rb", "test/support/database_cleaner.rb"
         copy_file "test.rake", "lib/tasks/test.rake"
 


### PR DESCRIPTION
This allows use of shorthand methods for `factory_girl` in specs:

``` ruby
describe Awesome do
  # do this
  before { create(:awesome) }

  # don't do this
  before { FactoryGirl.create(:awesome) }
end
```
