### PR TITLE
update dependency versions

### DIFF
--- a/thincloud-test.gemspec
+++ b/thincloud-test.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.version       = Thincloud::Test::VERSION
 
-  s.add_dependency "rails",                   "~> 3.2.8"
-  s.add_dependency "cane",                    "~> 2.4.0"
+  s.add_dependency "rails",                   "~> 3.2.9"
+  s.add_dependency "cane",                    "~> 2.5.0"
   s.add_dependency "capybara",                "~> 2.0.0"
   s.add_dependency "database_cleaner",        "~> 0.9.1"
   s.add_dependency "guard",                   "~> 1.5.4"
   s.add_dependency "factory_girl_rails",      "~> 4.1.0"
-  s.add_dependency "minitest",                "~> 4.2.0"
+  s.add_dependency "minitest",                "~> 4.3.3"
   s.add_dependency "minitest-rails",          "~> 0.3.0"
   s.add_dependency "guard-minitest",          "~> 0.5.0"
   s.add_dependency "minitest-rails-shoulda",  "~> 0.3.0"


### PR DESCRIPTION
This is for a 0.6 release and enables the use of `minitest/hell`.
